### PR TITLE
Add thenBy.min.js to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "multiple"
   ],
   "files": [
-    "thenBy.module.js"
+    "thenBy.module.js",
+    "thenBy.min.js"
   ],
   "author": "Teun Duynstee",
   "license": "Apache 2.0",


### PR DESCRIPTION
Hi,

This change allows to fetch the non-module exported version with npm, so I can keep using npm to manage my web dependencies.

thanks!